### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/ci_instance.php
+++ b/ci_instance.php
@@ -31,7 +31,7 @@ if (file_exists(APPPATH . 'config/' . ENVIRONMENT . '/constants.php')) {
 $charset = strtoupper(config_item('charset'));
 ini_set('default_charset', $charset);
 if (extension_loaded('mbstring')) {
-    define('MB_ENABLED', TRUE);
+    define('MB_ENABLED', true);
     // mbstring.internal_encoding is deprecated starting with PHP 5.6
     // and it's usage triggers E_DEPRECATED messages.
     @ini_set('mbstring.internal_encoding', $charset);
@@ -39,17 +39,17 @@ if (extension_loaded('mbstring')) {
     // That's utilized by CI_Utf8, but it's also done for consistency with iconv.
     mb_substitute_character('none');
 } else {
-    define('MB_ENABLED', FALSE);
+    define('MB_ENABLED', false);
 }
 // There's an ICONV_IMPL constant, but the PHP manual says that using
 // iconv's predefined constants is "strongly discouraged".
 if (extension_loaded('iconv')) {
-    define('ICONV_ENABLED', TRUE);
+    define('ICONV_ENABLED', true);
     // iconv.internal_encoding is deprecated starting with PHP 5.6
     // and it's usage triggers E_DEPRECATED messages.
     @ini_set('iconv.internal_encoding', $charset);
 } else {
-    define('ICONV_ENABLED', FALSE);
+    define('ICONV_ENABLED', false);
 }
 $GLOBALS['CFG'] = & load_class('Config', 'core');
 $GLOBALS['UNI'] = & load_class('Utf8', 'core');

--- a/libraries/CurrencyConverter.php
+++ b/libraries/CurrencyConverter.php
@@ -22,7 +22,7 @@ class CurrencyConverter
     public function __construct()
     {
         $this->CI =& get_instance();
-        $this->CI->config->load('currency_converter', TRUE);
+        $this->CI->config->load('currency_converter', true);
 
         $this->currencyApiKey = $this->CI->config->item('currency_api_key', 'currency_converter');
 
@@ -162,23 +162,23 @@ class CurrencyConverter
                 'id' => array(
                     'type' => 'INT',
                     'constraint' => 11,
-                    'unsigned' => TRUE,
-                    'auto_increment' => TRUE
+                    'unsigned' => true,
+                    'auto_increment' => true
                 ),
                 'from' => array(
                     'type' => 'VARCHAR',
                     'constraint' => '5',
-                    'null' => FALSE
+                    'null' => false
                 ),
                 'to' => array(
                     'type' => 'VARCHAR',
                     'constraint' => '5',
-                    'null' => FALSE
+                    'null' => false
                 ),
                 'rates' => array(
                     'type' => 'VARCHAR',
                     'constraint' => '10',
-                    'null' => FALSE
+                    'null' => false
                 ),
                 'created' => array(
                     'type' => 'DATETIME'
@@ -188,8 +188,8 @@ class CurrencyConverter
                 )
             ));
 
-            $this->CI->dbforge->add_key('id', TRUE);
-            $this->CI->dbforge->create_table($this->dbTable, TRUE);
+            $this->CI->dbforge->add_key('id', true);
+            $this->CI->dbforge->create_table($this->dbTable, true);
         }
     }
 

--- a/tests/database.php
+++ b/tests/database.php
@@ -2,7 +2,7 @@
 defined('BASEPATH') OR exit('No direct script access allowed');
 
 $active_group = 'default';
-$query_builder = TRUE;
+$query_builder = true;
 
 $db['default'] = array(
     'dsn'   => '',
@@ -12,17 +12,17 @@ $db['default'] = array(
     'database' => '',
     'dbdriver' => 'pdo',
     'dbprefix' => '',
-    'pconnect' => TRUE,
-    'db_debug' => TRUE,
-    'cache_on' => FALSE,
+    'pconnect' => true,
+    'db_debug' => true,
+    'cache_on' => false,
     'cachedir' => '',
     'char_set' => 'utf8',
     'dbcollat' => 'utf8_general_ci',
     'swap_pre' => '',
-    'encrypt' => FALSE,
-    'compress' => FALSE,
-    'stricton' => FALSE,
+    'encrypt' => false,
+    'compress' => false,
+    'stricton' => false,
     'failover' => array(),
-    'save_queries' => TRUE,
-    'autoinit' => TRUE
+    'save_queries' => true,
+    'autoinit' => true
 );


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!